### PR TITLE
run "brew style --fix awless.rb"

### DIFF
--- a/Formula/awless.rb
+++ b/Formula/awless.rb
@@ -1,16 +1,15 @@
 class Awless < Formula
   version = "v0.1.11"
 
-  desc "The Mighty CLI for AWS"
+  desc "Mighty CLI for AWS"
   homepage "https://github.com/wallix/awless"
   url "https://github.com/wallix/awless.git",
-        :tag => version
+        tag: version
   head "https://github.com/wallix/awless.git"
 
   bottle do
     root_url "https://github.com/wallix/homebrew-awless/releases/download/#{version}"
-    cellar :any_skip_relocation
-    sha256 "dbd1e5f4afd1de6fe00372bd8b6fffa9a448bbf461019094a5061b1b96924096" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "dbd1e5f4afd1de6fe00372bd8b6fffa9a448bbf461019094a5061b1b96924096"
   end
 
   depends_on "go" => :build
@@ -23,15 +22,15 @@ class Awless < Formula
 
     cd dir do
       # Make binary
-      system "go", "run", "release.go", "-tag", "v#{version}", "-brew", "-arch", "#{arch}", "-os", "darwin"
+      system "go", "run", "release.go", "-tag", "v#{version}", "-brew", "-arch", arch.to_s, "-os", "darwin"
       bin.install "awless"
 
       # Install bash completion
-      output = Utils.popen_read("#{bin}/awless completion bash")
+      output = Utils.safe_popen_read("#{bin}/awless", "completion", "bash")
       (bash_completion/"awless").write output
 
       # Install zsh completion
-      output = Utils.popen_read("#{bin}/awless completion zsh")
+      output = Utils.safe_popen_read("#{bin}/awless", "completion", "zsh")
       (zsh_completion/"_awless").write output
     end
   end


### PR DESCRIPTION
These warnings were showing up:

Warning: Calling `cellar` in a bottle block is deprecated! Use `brew
style --fix` on the formula to update the style or use `sha256` with a
`cellar:` argument instead.  Please report this issue to the
wallix/awless tap (not Homebrew/brew or Homebrew/core), or even better,
submit a PR to fix it.

Warning: Calling `sha256 "digest" => :tag` in a bottle block is
deprecated! Use `brew style --fix` on the formula to update the style or
use `sha256 tag: "digest"` instead.  Please report this issue to the
wallix/awless tap (not Homebrew/brew or Homebrew/core), or even better,
submit a PR to fix it.